### PR TITLE
Fix same struct and package name

### DIFF
--- a/factorytpl.go
+++ b/factorytpl.go
@@ -7,7 +7,7 @@ package {{ .PackageName }}
 
 import (
 {{- range .ImportPackages }}
-	"{{ . }}"
+	{{ . }}
 {{- end}}
 	"github.com/k-yomo/fixtory"
 	"testing"


### PR DESCRIPTION
I recently ran into a very annoying error when generating fixtures for tests, when the name of the structure is the same as the package name it is imported from (quite common in Go)). The error appears in the generated `BuildList` method:

```
func (ub * nodeBuilder) BuildList (n int) [] *node.Node {
...
for _, node: = range ub.builder.BuildList (n) {
nodes = append (nodes, node. (*node.Node))
}
...
}
```

The module name is shadowed by the variable from the loop. 
In the proposed PR, this behavior in the generated code was fixed by importing a module with the name prefixed by "_".

P.S.Thanks a lot for a very useful code generator. It saved me a lot of time.